### PR TITLE
fix: do not require token file for single role

### DIFF
--- a/nixos/k0s.nix
+++ b/nixos/k0s.nix
@@ -122,7 +122,7 @@ in {
             + optionalString (cfg.role == "controller+worker") " --enable-worker --no-taints"
             + optionalString (cfg.role != "single" && !cfg.isLeader) " --token-file=${cfg.tokenFile}";
         };
-        unitConfig = mkIf (!cfg.isLeader) {
+        unitConfig = mkIf (cfg.role != "single" && !cfg.isLeader) {
           ConditionPathExists = cfg.tokenFile;
         };
       };


### PR DESCRIPTION
The k0s token is not required when running a single node.